### PR TITLE
rlsのz方向の二次関数のパラメタをsrvでset/getできるように修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,11 @@ add_message_files(
 )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  SetRLSParameters.srv
+  GetRLSParameters.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -147,6 +147,13 @@ add_executable(object_trajectory_estimator
 target_link_libraries(object_trajectory_estimator
   ${catkin_LIBRARIES}
   )
+
+
+## srv
+add_executable(set_rls_param src/set_rls_param.cpp)
+target_link_libraries(set_rls_param ${catkin_LIBRARIES})
+add_executable(get_rls_param src/get_rls_param.cpp)
+target_link_libraries(get_rls_param ${catkin_LIBRARIES})
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/include/object_trajectory_estimator/recursive_least_square.hpp
+++ b/include/object_trajectory_estimator/recursive_least_square.hpp
@@ -14,6 +14,8 @@ public:
   double predict(double target_time);
   void reset();
 
+  void setParameters(double theta0, double theta1, double theta2);  // srvでsetする用
+
 public:
   int degree;                       // k次の多項式モデルでフィッティング
   double lambda;                    // 忘却係数
@@ -35,8 +37,6 @@ public:
 public:
   double vertexTime;
   std::vector<double> vertexPoint;
-  
-private:
   std::vector<RLS> rls3d;
 };
 

--- a/src/get_rls_param.cpp
+++ b/src/get_rls_param.cpp
@@ -1,0 +1,32 @@
+#include "ros/ros.h"
+#include "object_trajectory_estimator/GetRLSParameters.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "get_parameters_client");
+    if (argc != 1)
+    {
+        ROS_INFO("Usage: get_parameters_client");
+        return 1;
+    }
+
+    ros::NodeHandle nh;
+    ros::ServiceClient client = nh.serviceClient<object_trajectory_estimator::GetRLSParameters>("/ObjectTrajectoryEstimator/get_rls_parameters");
+
+    object_trajectory_estimator::GetRLSParameters srv;
+
+    if (client.call(srv))
+    {
+        ROS_INFO("Parameters received:");
+        ROS_INFO("Parameter 1: %f", srv.response.params[0]);
+        ROS_INFO("Parameter 2: %f", srv.response.params[1]);
+        ROS_INFO("Parameter 3: %f", srv.response.params[2]);
+    }
+    else
+    {
+        ROS_ERROR("Failed to call service get_rls_parameters");
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/recursive_least_square.cpp
+++ b/src/recursive_least_square.cpp
@@ -41,6 +41,14 @@ Eigen::VectorXd RLS::getParameters() const {
   return theta;
 }
 
+void RLS::setParameters(double theta0, double theta1, double theta2) {
+  if (theta.size() == 3) {
+    theta[0] = theta0;
+    theta[1] = theta1;
+    theta[2] = theta2;
+  }
+}
+
 double RLS::predict(double target_time) {
   Eigen::VectorXd time_vector(degree+1);
   for (int i=0;i<degree+1;i++) {

--- a/src/set_rls_param.cpp
+++ b/src/set_rls_param.cpp
@@ -1,0 +1,39 @@
+#include "ros/ros.h"
+#include "object_trajectory_estimator/SetRLSParameters.h"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "set_parameters_client");
+  if (argc != 4)
+    {
+      ROS_INFO("usage: set_parameters_client X Y Z");
+      return 1;
+    }
+
+  ros::NodeHandle nh;
+  ros::ServiceClient client = nh.serviceClient<object_trajectory_estimator::SetRLSParameters>("/ObjectTrajectoryEstimator/set_rls_parameters");
+  
+  object_trajectory_estimator::SetRLSParameters srv;
+  srv.request.params[0] = atof(argv[1]);
+  srv.request.params[1] = atof(argv[2]);
+  srv.request.params[2] = atof(argv[3]);
+  
+  if (client.call(srv))
+    {
+      if (srv.response.success)
+        {
+	  ROS_INFO("Parameters set successfully");
+        }
+      else
+        {
+	  ROS_WARN("Failed to set parameters");
+        }
+    }
+  else
+    {
+      ROS_ERROR("Failed to call service set_parameters");
+      return 1;
+    }
+  
+  return 0;
+}

--- a/srv/GetRLSParameters.srv
+++ b/srv/GetRLSParameters.srv
@@ -1,0 +1,2 @@
+---
+float64[3] params

--- a/srv/SetRLSParameters.srv
+++ b/srv/SetRLSParameters.srv
@@ -1,0 +1,3 @@
+float64[3] params
+---
+bool success


### PR DESCRIPTION
rosrun object_trajectory_estimator set_rls_param X Y Z
rourun object_trajectory_estimator get_rls_param
